### PR TITLE
Cleanup, refactor and implement save/restore

### DIFF
--- a/CasterSoundboard/.gitignore
+++ b/CasterSoundboard/.gitignore
@@ -1,0 +1,7 @@
+.qmake.stash
+*.o
+CasterSoundboard
+*.app
+Makefile
+moc_*
+qrc_*

--- a/CasterSoundboard/CasterBoard.cpp
+++ b/CasterSoundboard/CasterBoard.cpp
@@ -24,603 +24,76 @@
 #include "CasterPlayer.h"
 #include <QGridLayout>
 
+CasterBoardLayout::CasterBoardLayout(const QString &letter, int posY, int posX)
+{
+    this->letter = letter;
+    this->posY = posY;
+    this->posX = posX;
+}
+
 //Constructor=============================================
 CasterBoard::CasterBoard(QWidget* parent) : QWidget(parent)
 {
+    layout[Qt::Key_1]     = new CasterBoardLayout("1", 0, 0);
+    layout[Qt::Key_2]     = new CasterBoardLayout("2", 0, 1);
+    layout[Qt::Key_3]     = new CasterBoardLayout("3", 0, 2);
+    layout[Qt::Key_4]     = new CasterBoardLayout("4", 0, 3);
+    layout[Qt::Key_5]     = new CasterBoardLayout("5", 0, 4);
+    layout[Qt::Key_6]     = new CasterBoardLayout("6", 0, 5);
+    layout[Qt::Key_7]     = new CasterBoardLayout("7", 0, 6);
+    layout[Qt::Key_8]     = new CasterBoardLayout("8", 0, 7);
+
+    layout[Qt::Key_Q]     = new CasterBoardLayout("Q", 1, 0);
+    layout[Qt::Key_W]     = new CasterBoardLayout("W", 1, 1);
+    layout[Qt::Key_E]     = new CasterBoardLayout("E", 1, 2);
+    layout[Qt::Key_R]     = new CasterBoardLayout("R", 1, 3);
+    layout[Qt::Key_T]     = new CasterBoardLayout("T", 1, 4);
+    layout[Qt::Key_Y]     = new CasterBoardLayout("Y", 1, 5);
+    layout[Qt::Key_U]     = new CasterBoardLayout("U", 1, 6);
+    layout[Qt::Key_I]     = new CasterBoardLayout("I", 1, 7);
+
+    layout[Qt::Key_A]     = new CasterBoardLayout("A", 2, 0);
+    layout[Qt::Key_S]     = new CasterBoardLayout("S", 2, 1);
+    layout[Qt::Key_D]     = new CasterBoardLayout("D", 2, 2);
+    layout[Qt::Key_F]     = new CasterBoardLayout("F", 2, 3);
+    layout[Qt::Key_G]     = new CasterBoardLayout("G", 2, 4);
+    layout[Qt::Key_H]     = new CasterBoardLayout("H", 2, 5);
+    layout[Qt::Key_J]     = new CasterBoardLayout("J", 2, 6);
+    layout[Qt::Key_K]     = new CasterBoardLayout("K", 2, 7);
+
+    layout[Qt::Key_Z]     = new CasterBoardLayout("Z", 3, 0);
+    layout[Qt::Key_X]     = new CasterBoardLayout("X", 3, 1);
+    layout[Qt::Key_C]     = new CasterBoardLayout("C", 3, 2);
+    layout[Qt::Key_V]     = new CasterBoardLayout("V", 3, 3);
+    layout[Qt::Key_B]     = new CasterBoardLayout("B", 3, 4);
+    layout[Qt::Key_N]     = new CasterBoardLayout("N", 3, 5);
+    layout[Qt::Key_M]     = new CasterBoardLayout("M", 3, 6);
+    layout[Qt::Key_Comma] = new CasterBoardLayout(",", 3, 7);
+
     QGridLayout *boardLayout = new QGridLayout(this);
 
-    //WIDGETS
-    player1 = new CasterPlayerWidget;
-    player1->setHotKeyLetter("1");
-    player2 = new CasterPlayerWidget;
-    player2->setHotKeyLetter("2");
-    player3 = new CasterPlayerWidget;
-    player3->setHotKeyLetter("3");
-    player4 = new CasterPlayerWidget;
-    player4->setHotKeyLetter("4");
-    player5 = new CasterPlayerWidget;
-    player5->setHotKeyLetter("5");
-    player6 = new CasterPlayerWidget;
-    player6->setHotKeyLetter("6");
-    player7 = new CasterPlayerWidget;
-    player7->setHotKeyLetter("7");
-    player8 = new CasterPlayerWidget;
-    player8->setHotKeyLetter("8");
+    QHash<int, CasterBoardLayout*>::const_iterator i = layout.constBegin();
 
-    playerQ = new CasterPlayerWidget;
-    playerQ->setHotKeyLetter("Q");
-    playerW = new CasterPlayerWidget;
-    playerW->setHotKeyLetter("W");
-    playerE = new CasterPlayerWidget;
-    playerE->setHotKeyLetter("E");
-    playerR = new CasterPlayerWidget;
-    playerR->setHotKeyLetter("R");
-    playerT = new CasterPlayerWidget;
-    playerT->setHotKeyLetter("T");
-    playerY = new CasterPlayerWidget;
-    playerY->setHotKeyLetter("Y");
-    playerU = new CasterPlayerWidget;
-    playerU->setHotKeyLetter("U");
-    playerI = new CasterPlayerWidget;
-    playerI->setHotKeyLetter("I");
-
-    playerA = new CasterPlayerWidget;
-    playerA->setHotKeyLetter("A");
-    playerS = new CasterPlayerWidget;
-    playerS->setHotKeyLetter("S");
-    playerD = new CasterPlayerWidget;
-    playerD->setHotKeyLetter("D");
-    playerF = new CasterPlayerWidget;
-    playerF->setHotKeyLetter("F");
-    playerG = new CasterPlayerWidget;
-    playerG->setHotKeyLetter("G");
-    playerH = new CasterPlayerWidget;
-    playerH->setHotKeyLetter("H");
-    playerJ = new CasterPlayerWidget;
-    playerJ->setHotKeyLetter("J");
-    playerK = new CasterPlayerWidget;
-    playerK->setHotKeyLetter("K");
-
-    playerZ = new CasterPlayerWidget;
-    playerZ->setHotKeyLetter("Z");
-    playerX = new CasterPlayerWidget;
-    playerX->setHotKeyLetter("X");
-    playerC = new CasterPlayerWidget;
-    playerC->setHotKeyLetter("C");
-    playerV = new CasterPlayerWidget;
-    playerV->setHotKeyLetter("V");
-    playerB = new CasterPlayerWidget;
-    playerB->setHotKeyLetter("B");
-    playerN = new CasterPlayerWidget;
-    playerN->setHotKeyLetter("N");
-    playerM = new CasterPlayerWidget;
-    playerM->setHotKeyLetter("M");
-    playerCOMMA = new CasterPlayerWidget;
-    playerCOMMA->setHotKeyLetter(",");
-
-    //ADD TO LAYOUT
-    boardLayout->addWidget(player1, 0,0);
-    boardLayout->addWidget(player2, 0,1);
-    boardLayout->addWidget(player3, 0,2);
-    boardLayout->addWidget(player4, 0,3);
-    boardLayout->addWidget(player5, 0,4);
-    boardLayout->addWidget(player6, 0,5);
-    boardLayout->addWidget(player7, 0,6);
-    boardLayout->addWidget(player8, 0,7);
-
-    boardLayout->addWidget(playerQ, 1,0);
-    boardLayout->addWidget(playerW, 1,1);
-    boardLayout->addWidget(playerE, 1,2);
-    boardLayout->addWidget(playerR, 1,3);
-    boardLayout->addWidget(playerT, 1,4);
-    boardLayout->addWidget(playerY, 1,5);
-    boardLayout->addWidget(playerU, 1,6);
-    boardLayout->addWidget(playerI, 1,7);
-
-    boardLayout->addWidget(playerA, 2,0);
-    boardLayout->addWidget(playerS, 2,1);
-    boardLayout->addWidget(playerD, 2,2);
-    boardLayout->addWidget(playerF, 2,3);
-    boardLayout->addWidget(playerG, 2,4);
-    boardLayout->addWidget(playerH, 2,5);
-    boardLayout->addWidget(playerJ, 2,6);
-    boardLayout->addWidget(playerK, 2,7);
-
-    boardLayout->addWidget(playerZ, 3,0);
-    boardLayout->addWidget(playerX, 3,1);
-    boardLayout->addWidget(playerC, 3,2);
-    boardLayout->addWidget(playerV, 3,3);
-    boardLayout->addWidget(playerB, 3,4);
-    boardLayout->addWidget(playerN, 3,5);
-    boardLayout->addWidget(playerM, 3,6);
-    boardLayout->addWidget(playerCOMMA, 3,7);
+    while (i != layout.constEnd()) {
+        CasterPlayerWidget *widget = new CasterPlayerWidget();
+        i.value()->widget = widget;
+        widget->setHotKeyLetter(i.value()->letter);
+        boardLayout->addWidget(widget, i.value()->posY, i.value()->posX);
+        ++i;
+    }
 }
 
 void CasterBoard::keyReleaseEvent(QKeyEvent *event)
 {
     //Handles All Hot Key Behavior
-    //BOARD 1
-    if(event->key() == Qt::Key_1)
-    {
-        if(player1->player->state() == QMediaPlayer::PlayingState)
-        {
-            player1->stopSound();
-        }
-        else if (player1->player->state() == QMediaPlayer::PausedState)
-        {
-            player1->playSound();
-        }
-        else if (player1->player->state() == QMediaPlayer::StoppedState)
-        {
-            player1->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_2)
-    {
-        if(player2->player->state() == QMediaPlayer::PlayingState)
-        {
-            player2->stopSound();
-        }
-        else if (player2->player->state() == QMediaPlayer::PausedState)
-        {
-            player2->playSound();
-        }
-        else if (player2->player->state() == QMediaPlayer::StoppedState)
-        {
-            player2->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_3)
-    {
-        if(player3->player->state() == QMediaPlayer::PlayingState)
-        {
-            player3->stopSound();
-        }
-        else if (player3->player->state() == QMediaPlayer::PausedState)
-        {
-            player3->playSound();
-        }
-        else if (player3->player->state() == QMediaPlayer::StoppedState)
-        {
-            player3->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_4)
-    {
-        if(player4->player->state() == QMediaPlayer::PlayingState)
-        {
-            player4->stopSound();
-        }
-        else if (player4->player->state() == QMediaPlayer::PausedState)
-        {
-            player4->playSound();
-        }
-        else if (player4->player->state() == QMediaPlayer::StoppedState)
-        {
-            player4->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_5)
-    {
-        if(player5->player->state() == QMediaPlayer::PlayingState)
-        {
-            player5->stopSound();
-        }
-        else if (player5->player->state() == QMediaPlayer::PausedState)
-        {
-            player5->playSound();
-        }
-        else if (player5->player->state() == QMediaPlayer::StoppedState)
-        {
-            player5->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_6)
-    {
-        if(player6->player->state() == QMediaPlayer::PlayingState)
-        {
-            player6->stopSound();
-        }
-        else if (player6->player->state() == QMediaPlayer::PausedState)
-        {
-            player6->playSound();
-        }
-        else if (player6->player->state() == QMediaPlayer::StoppedState)
-        {
-            player6->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_7)
-    {
-        if(player7->player->state() == QMediaPlayer::PlayingState)
-        {
-            player7->stopSound();
-        }
-        else if (player7->player->state() == QMediaPlayer::PausedState)
-        {
-            player7->playSound();
-        }
-        else if (player7->player->state() == QMediaPlayer::StoppedState)
-        {
-            player7->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_8)
-    {
-        if(player8->player->state() == QMediaPlayer::PlayingState)
-        {
-            player8->stopSound();
-        }
-        else if (player8->player->state() == QMediaPlayer::PausedState)
-        {
-            player8->playSound();
-        }
-        else if (player8->player->state() == QMediaPlayer::StoppedState)
-        {
-            player8->playSound();
-        }
-    }
-    //BOARD 2
-    else if(event->key() == Qt::Key_Q)
-    {
-        if(playerQ->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerQ->stopSound();
-        }
-        else if (playerQ->player->state() == QMediaPlayer::PausedState)
-        {
-            playerQ->playSound();
-        }
-        else if (playerQ->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerQ->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_W)
-    {
-        if(playerW->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerW->stopSound();
-        }
-        else if (playerW->player->state() == QMediaPlayer::PausedState)
-        {
-            playerW->playSound();
-        }
-        else if (playerW->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerW->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_E)
-    {
-        if(playerE->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerE->stopSound();
-        }
-        else if (playerE->player->state() == QMediaPlayer::PausedState)
-        {
-            playerE->playSound();
-        }
-        else if (playerE->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerE->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_R)
-    {
-        if(playerR->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerR->stopSound();
-        }
-        else if (playerR->player->state() == QMediaPlayer::PausedState)
-        {
-            playerR->playSound();
-        }
-        else if (playerR->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerR->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_T)
-    {
-        if(playerT->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerT->stopSound();
-        }
-        else if (playerT->player->state() == QMediaPlayer::PausedState)
-        {
-            playerT->playSound();
-        }
-        else if (playerT->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerT->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_Y)
-    {
-        if(playerY->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerY->stopSound();
-        }
-        else if (playerY->player->state() == QMediaPlayer::PausedState)
-        {
-            playerY->playSound();
-        }
-        else if (playerY->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerY->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_U)
-    {
-        if(playerU->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerU->stopSound();
-        }
-        else if (playerU->player->state() == QMediaPlayer::PausedState)
-        {
-            playerU->playSound();
-        }
-        else if (playerU->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerU->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_I)
-    {
-        if(playerI->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerI->stopSound();
-        }
-        else if (playerI->player->state() == QMediaPlayer::PausedState)
-        {
-            playerI->playSound();
-        }
-        else if (playerI->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerI->playSound();
-        }
-    }
-    //BOARD 3
-    else if(event->key() == Qt::Key_A)
-    {
-        if(playerA->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerA->stopSound();
-        }
-        else if (playerA->player->state() == QMediaPlayer::PausedState)
-        {
-            playerA->playSound();
-        }
-        else if (playerA->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerA->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_S)
-    {
-        if(playerS->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerS->stopSound();
-        }
-        else if (playerS->player->state() == QMediaPlayer::PausedState)
-        {
-            playerS->playSound();
-        }
-        else if (playerS->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerS->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_D)
-    {
-        if(playerD->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerD->stopSound();
-        }
-        else if (playerD->player->state() == QMediaPlayer::PausedState)
-        {
-            playerD->playSound();
-        }
-        else if (playerD->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerD->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_F)
-    {
-        if(playerF->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerF->stopSound();
-        }
-        else if (playerF->player->state() == QMediaPlayer::PausedState)
-        {
-            playerF->playSound();
-        }
-        else if (playerF->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerF->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_G)
-    {
-        if(playerG->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerG->stopSound();
-        }
-        else if (playerG->player->state() == QMediaPlayer::PausedState)
-        {
-            playerG->playSound();
-        }
-        else if (playerG->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerG->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_H)
-    {
-        if(playerH->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerH->stopSound();
-        }
-        else if (playerH->player->state() == QMediaPlayer::PausedState)
-        {
-            playerH->playSound();
-        }
-        else if (playerH->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerH->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_J)
-    {
-        if(playerJ->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerJ->stopSound();
-        }
-        else if (playerJ->player->state() == QMediaPlayer::PausedState)
-        {
-            playerJ->playSound();
-        }
-        else if (playerJ->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerJ->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_K)
-    {
-        if(playerK->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerK->stopSound();
-        }
-        else if (playerK->player->state() == QMediaPlayer::PausedState)
-        {
-            playerK->playSound();
-        }
-        else if (playerK->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerK->playSound();
-        }
-    }
-    //BOARD 4
-    else if(event->key() == Qt::Key_Z)
-    {
-        if(playerZ->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerZ->stopSound();
-        }
-        else if (playerZ->player->state() == QMediaPlayer::PausedState)
-        {
-            playerZ->playSound();
-        }
-        else if (playerZ->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerZ->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_X)
-    {
-        if(playerX->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerX->stopSound();
-        }
-        else if (playerX->player->state() == QMediaPlayer::PausedState)
-        {
-            playerX->playSound();
-        }
-        else if (playerX->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerX->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_C)
-    {
-        if(playerC->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerC->stopSound();
-        }
-        else if (playerC->player->state() == QMediaPlayer::PausedState)
-        {
-            playerC->playSound();
-        }
-        else if (playerC->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerC->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_V)
-    {
-        if(playerV->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerV->stopSound();
-        }
-        else if (playerV->player->state() == QMediaPlayer::PausedState)
-        {
-            playerV->playSound();
-        }
-        else if (playerV->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerV->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_B)
-    {
-        if(playerB->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerB->stopSound();
-        }
-        else if (playerB->player->state() == QMediaPlayer::PausedState)
-        {
-            playerB->playSound();
-        }
-        else if (playerB->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerB->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_N)
-    {
-        if(playerN->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerN->stopSound();
-        }
-        else if (playerN->player->state() == QMediaPlayer::PausedState)
-        {
-            playerN->playSound();
-        }
-        else if (playerN->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerN->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_M)
-    {
-        if(playerM->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerM->stopSound();
-        }
-        else if (playerM->player->state() == QMediaPlayer::PausedState)
-        {
-            playerM->playSound();
-        }
-        else if (playerM->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerM->playSound();
-        }
-    }
-    else if(event->key() == Qt::Key_Comma)
-    {
-        if(playerCOMMA->player->state() == QMediaPlayer::PlayingState)
-        {
-            playerCOMMA->stopSound();
-        }
-        else if (playerCOMMA->player->state() == QMediaPlayer::PausedState)
-        {
-            playerCOMMA->playSound();
-        }
-        else if (playerCOMMA->player->state() == QMediaPlayer::StoppedState)
-        {
-            playerCOMMA->playSound();
-        }
+    if (!layout.contains(event->key()))
+        return;
+
+    CasterPlayerWidget *widget = layout.value(event->key())->widget;
+
+    switch (widget->player->state()) {
+        case QMediaPlayer::PlayingState: widget->stopSound(); break;
+        case QMediaPlayer::PausedState:  widget->playSound(); break;
+        case QMediaPlayer::StoppedState: widget->playSound(); break;
     }
 }

--- a/CasterSoundboard/CasterBoard.cpp
+++ b/CasterSoundboard/CasterBoard.cpp
@@ -76,6 +76,32 @@ CasterBoard::CasterBoard(QWidget* parent) : QWidget(parent)
     }
 }
 
+void CasterBoard::saveLayout(QSettings &settings)
+{
+    QHash<int, CasterBoardLayout*>::const_iterator i = layout.constBegin();
+
+    while (i != layout.constEnd()) {
+        CasterPlayerWidget *widget = i.value()->widget;
+        QString keystr = QString::number(i.key());
+        if (!widget->soundFilePath->isEmpty())
+            settings.setValue(keystr, *widget->soundFilePath);
+        ++i;
+    }
+}
+
+void CasterBoard::restoreLayout(const QSettings &settings)
+{
+    QHash<int, CasterBoardLayout*>::const_iterator i = layout.constBegin();
+
+    while (i != layout.constEnd()) {
+        CasterPlayerWidget *widget = i.value()->widget;
+        QString keystr = QString::number(i.key());
+        if (settings.contains(keystr))
+            widget->assignFile(settings.value(keystr).toString());
+        ++i;
+    }
+}
+
 void CasterBoard::keyReleaseEvent(QKeyEvent *event)
 {
     //Handles All Hot Key Behavior

--- a/CasterSoundboard/CasterBoard.cpp
+++ b/CasterSoundboard/CasterBoard.cpp
@@ -27,78 +27,63 @@
 //Constructor=============================================
 CasterBoard::CasterBoard(QWidget* parent) : QWidget(parent)
 {
-    layout[Qt::Key_1]     = new CasterBoardLayout("1", 0, 0);
-    layout[Qt::Key_2]     = new CasterBoardLayout("2", 0, 1);
-    layout[Qt::Key_3]     = new CasterBoardLayout("3", 0, 2);
-    layout[Qt::Key_4]     = new CasterBoardLayout("4", 0, 3);
-    layout[Qt::Key_5]     = new CasterBoardLayout("5", 0, 4);
-    layout[Qt::Key_6]     = new CasterBoardLayout("6", 0, 5);
-    layout[Qt::Key_7]     = new CasterBoardLayout("7", 0, 6);
-    layout[Qt::Key_8]     = new CasterBoardLayout("8", 0, 7);
+    Qt::Key const keys[] = {
+        Qt::Key_1, Qt::Key_2, Qt::Key_3, Qt::Key_4,
+        Qt::Key_5, Qt::Key_6, Qt::Key_7, Qt::Key_8,
 
-    layout[Qt::Key_Q]     = new CasterBoardLayout("Q", 1, 0);
-    layout[Qt::Key_W]     = new CasterBoardLayout("W", 1, 1);
-    layout[Qt::Key_E]     = new CasterBoardLayout("E", 1, 2);
-    layout[Qt::Key_R]     = new CasterBoardLayout("R", 1, 3);
-    layout[Qt::Key_T]     = new CasterBoardLayout("T", 1, 4);
-    layout[Qt::Key_Y]     = new CasterBoardLayout("Y", 1, 5);
-    layout[Qt::Key_U]     = new CasterBoardLayout("U", 1, 6);
-    layout[Qt::Key_I]     = new CasterBoardLayout("I", 1, 7);
+        Qt::Key_Q, Qt::Key_W, Qt::Key_E, Qt::Key_R,
+        Qt::Key_T, Qt::Key_Y, Qt::Key_U, Qt::Key_I,
 
-    layout[Qt::Key_A]     = new CasterBoardLayout("A", 2, 0);
-    layout[Qt::Key_S]     = new CasterBoardLayout("S", 2, 1);
-    layout[Qt::Key_D]     = new CasterBoardLayout("D", 2, 2);
-    layout[Qt::Key_F]     = new CasterBoardLayout("F", 2, 3);
-    layout[Qt::Key_G]     = new CasterBoardLayout("G", 2, 4);
-    layout[Qt::Key_H]     = new CasterBoardLayout("H", 2, 5);
-    layout[Qt::Key_J]     = new CasterBoardLayout("J", 2, 6);
-    layout[Qt::Key_K]     = new CasterBoardLayout("K", 2, 7);
+        Qt::Key_A, Qt::Key_S, Qt::Key_D, Qt::Key_F,
+        Qt::Key_G, Qt::Key_H, Qt::Key_J, Qt::Key_K,
 
-    layout[Qt::Key_Z]     = new CasterBoardLayout("Z", 3, 0);
-    layout[Qt::Key_X]     = new CasterBoardLayout("X", 3, 1);
-    layout[Qt::Key_C]     = new CasterBoardLayout("C", 3, 2);
-    layout[Qt::Key_V]     = new CasterBoardLayout("V", 3, 3);
-    layout[Qt::Key_B]     = new CasterBoardLayout("B", 3, 4);
-    layout[Qt::Key_N]     = new CasterBoardLayout("N", 3, 5);
-    layout[Qt::Key_M]     = new CasterBoardLayout("M", 3, 6);
-    layout[Qt::Key_Comma] = new CasterBoardLayout(",", 3, 7);
+        Qt::Key_Z, Qt::Key_X, Qt::Key_C, Qt::Key_V,
+        Qt::Key_B, Qt::Key_N, Qt::Key_M, Qt::Key_Comma,
+    };
+
+    QString const letters =
+        "12345678"
+        "QWERTYUI"
+        "ASDFGHJK"
+        "ZXCVBNM,";
+
+    int offset = 0;
+    for (QChar const letter : letters) {
+        int posX = offset / 8;
+        int posY = offset % 8;
+        layout[keys[offset++]] = new CasterBoardLayout(letter, posX, posY);
+    }
 
     QGridLayout *boardLayout = new QGridLayout(this);
 
-    QHash<int, CasterBoardLayout*>::const_iterator i = layout.constBegin();
-
-    while (i != layout.constEnd()) {
+    for (int key : layout.keys()) {
+        CasterBoardLayout *value = layout.value(key);
         CasterPlayerWidget *widget = new CasterPlayerWidget();
-        i.value()->widget = widget;
-        widget->setHotKeyLetter(i.value()->letter);
-        boardLayout->addWidget(widget, i.value()->posY, i.value()->posX);
-        ++i;
+        value->widget = widget;
+        widget->setHotKeyLetter(value->letter);
+        boardLayout->addWidget(widget, value->posY, value->posX);
     }
 }
 
 void CasterBoard::saveLayout(QSettings &settings)
 {
-    QHash<int, CasterBoardLayout*>::const_iterator i = layout.constBegin();
-
-    while (i != layout.constEnd()) {
-        CasterPlayerWidget *widget = i.value()->widget;
-        QString keystr = QString::number(i.key());
+    for (int key : layout.keys()) {
+        CasterBoardLayout *value = layout.value(key);
+        CasterPlayerWidget *widget = value->widget;
+        QString keystr = QString::number(key);
         if (!widget->soundFilePath->isEmpty())
             settings.setValue(keystr, *widget->soundFilePath);
-        ++i;
     }
 }
 
 void CasterBoard::restoreLayout(const QSettings &settings)
 {
-    QHash<int, CasterBoardLayout*>::const_iterator i = layout.constBegin();
-
-    while (i != layout.constEnd()) {
-        CasterPlayerWidget *widget = i.value()->widget;
-        QString keystr = QString::number(i.key());
+    for (int key : layout.keys()) {
+        CasterBoardLayout *value = layout.value(key);
+        CasterPlayerWidget *widget = value->widget;
+        QString keystr = QString::number(key);
         if (settings.contains(keystr))
             widget->assignFile(settings.value(keystr).toString());
-        ++i;
     }
 }
 

--- a/CasterSoundboard/CasterBoard.cpp
+++ b/CasterSoundboard/CasterBoard.cpp
@@ -24,13 +24,6 @@
 #include "CasterPlayer.h"
 #include <QGridLayout>
 
-CasterBoardLayout::CasterBoardLayout(const QString &letter, int posY, int posX)
-{
-    this->letter = letter;
-    this->posY = posY;
-    this->posX = posX;
-}
-
 //Constructor=============================================
 CasterBoard::CasterBoard(QWidget* parent) : QWidget(parent)
 {

--- a/CasterSoundboard/CasterBoard.h
+++ b/CasterSoundboard/CasterBoard.h
@@ -25,6 +25,7 @@
 #include "CasterBoardLayout.h"
 #include <QWidget>
 #include <QHash>
+#include <QSettings>
 
 //forward declarations
 class CasterPlayerWidget;
@@ -35,6 +36,9 @@ class CasterBoard : public QWidget //inherit from QWidget
 public:
     //Constructor
     CasterBoard(QWidget* parent = 0); //don't forget to pass the parent
+
+    void saveLayout(QSettings &settings);
+    void restoreLayout(const QSettings &settings);
 
     //Properties
 

--- a/CasterSoundboard/CasterBoard.h
+++ b/CasterSoundboard/CasterBoard.h
@@ -22,22 +22,12 @@
  */
 #ifndef CASTERBOARD_H
 #define CASTERBOARD_H
+#include "CasterBoardLayout.h"
 #include <QWidget>
 #include <QHash>
 
 //forward declarations
 class CasterPlayerWidget;
-
-class CasterBoardLayout : public QObject
-{
-    Q_OBJECT
-public:
-    CasterBoardLayout(const QString &letter, int posY, int posX);
-
-    QString letter;
-    int posX, posY;
-    CasterPlayerWidget *widget;
-};
 
 class CasterBoard : public QWidget //inherit from QWidget
 {

--- a/CasterSoundboard/CasterBoard.h
+++ b/CasterSoundboard/CasterBoard.h
@@ -23,9 +23,21 @@
 #ifndef CASTERBOARD_H
 #define CASTERBOARD_H
 #include <QWidget>
+#include <QHash>
 
 //forward declarations
 class CasterPlayerWidget;
+
+class CasterBoardLayout : public QObject
+{
+    Q_OBJECT
+public:
+    CasterBoardLayout(const QString &letter, int posY, int posX);
+
+    QString letter;
+    int posX, posY;
+    CasterPlayerWidget *widget;
+};
 
 class CasterBoard : public QWidget //inherit from QWidget
 {
@@ -42,44 +54,7 @@ protected:
     void keyReleaseEvent(QKeyEvent *event);//Capture Hot Keys
 
 private:
-    //Private Methods
-
-    //WIDGETS
-    CasterPlayerWidget *player1;
-    CasterPlayerWidget *player2;
-    CasterPlayerWidget *player3;
-    CasterPlayerWidget *player4;
-    CasterPlayerWidget *player5;
-    CasterPlayerWidget *player6;
-    CasterPlayerWidget *player7;
-    CasterPlayerWidget *player8;
-
-    CasterPlayerWidget *playerQ;
-    CasterPlayerWidget *playerW;
-    CasterPlayerWidget *playerE;
-    CasterPlayerWidget *playerR;
-    CasterPlayerWidget *playerT;
-    CasterPlayerWidget *playerY;
-    CasterPlayerWidget *playerU;
-    CasterPlayerWidget *playerI;
-
-    CasterPlayerWidget *playerA;
-    CasterPlayerWidget *playerS;
-    CasterPlayerWidget *playerD;
-    CasterPlayerWidget *playerF;
-    CasterPlayerWidget *playerG;
-    CasterPlayerWidget *playerH;
-    CasterPlayerWidget *playerJ;
-    CasterPlayerWidget *playerK;
-
-    CasterPlayerWidget *playerZ;
-    CasterPlayerWidget *playerX;
-    CasterPlayerWidget *playerC;
-    CasterPlayerWidget *playerV;
-    CasterPlayerWidget *playerB;
-    CasterPlayerWidget *playerN;
-    CasterPlayerWidget *playerM;
-    CasterPlayerWidget *playerCOMMA;
+    QHash<int, CasterBoardLayout*> layout;
 
 signals:
     //SIGNALS

--- a/CasterSoundboard/CasterBoardLayout.cpp
+++ b/CasterSoundboard/CasterBoardLayout.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 aszlig
+ *
+ * This file is part of CasterSoundboard. An application for playing hot-keyed
+ * sounds. For more information, please visit:
+ *
+ * https://github.com/JupiterBroadcasting/CasterSoundboard
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU LESSER GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU LESSER GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU LESSER GENERAL PUBLIC LICENSE
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+#include "CasterBoardLayout.h"
+
+CasterBoardLayout::CasterBoardLayout(const QString &letter, int posY, int posX)
+{
+    this->letter = letter;
+    this->posY = posY;
+    this->posX = posX;
+}

--- a/CasterSoundboard/CasterBoardLayout.h
+++ b/CasterSoundboard/CasterBoardLayout.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 aszlig
+ *
+ * This file is part of CasterSoundboard. An application for playing hot-keyed
+ * sounds. For more information, please visit:
+ *
+ * https://github.com/JupiterBroadcasting/CasterSoundboard
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU LESSER GENERAL PUBLIC LICENSE
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU LESSER GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU LESSER GENERAL PUBLIC LICENSE
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+#ifndef CASTERBOARDLAYOUT_H
+#define CASTERBOARDLAYOUT_H
+#include <QObject>
+
+#include "CasterPlayer.h"
+
+class CasterBoardLayout : public QObject
+{
+    Q_OBJECT
+public:
+    CasterBoardLayout(const QString &letter, int posY, int posX);
+
+    QString letter;
+    int posX, posY;
+    CasterPlayerWidget *widget;
+};
+
+#endif // CASTERBOARD_H

--- a/CasterSoundboard/CasterPlayer.cpp
+++ b/CasterSoundboard/CasterPlayer.cpp
@@ -279,11 +279,24 @@ int CasterPlayerWidget::getProgressWidth()
     return (int)(this->progress * (float)(this->width()));
 }
 
+//Public Methods
+//===============Player Methods=================
+void CasterPlayerWidget::playSound()
+{
+    player->setVolume(volume);
+    player->play();
+}
+
+void CasterPlayerWidget::stopSound()
+{
+    player->setVolume(volume);
+    player->stop();
+}
+
 bool CasterPlayerWidget::assignFile(const QString &path)
 {
     if(openFiles(QStringList(path)))
     {
-        playSound();
         return true;
     }
     else
@@ -298,20 +311,6 @@ bool CasterPlayerWidget::assignFile(const QString &path)
         return false;
     }
 
-}
-
-//Public Methods
-//===============Player Methods=================
-void CasterPlayerWidget::playSound()
-{
-    player->setVolume(volume);
-    player->play();
-}
-
-void CasterPlayerWidget::stopSound()
-{
-    player->setVolume(volume);
-    player->stop();
 }
 //==================================================
 
@@ -339,8 +338,10 @@ void CasterPlayerWidget::dropEvent(QDropEvent *event)
     if (mimeData->hasUrls())
     {
         QString path = mimeData->urls().at(0).toLocalFile();
-        if (assignFile(path))
+        if (assignFile(path)) {
+            playSound();
             event->acceptProposedAction();
+        }
     }
 }
 
@@ -357,8 +358,8 @@ void CasterPlayerWidget::mousePressEvent(QMouseEvent* event)
         "Audio files (*.mp3 *.wav *.ogg *.flac *.m4a);;"
         "Video files (*.mp4 *.mov *.ogv *.avi *.mpg *.wmv)"
     );
-    if (!path.isNull())
-        assignFile(path);
+    if (!path.isNull() && assignFile(path))
+        playSound();
 }
 
 bool CasterPlayerWidget::openFiles(const QStringList& pathList)

--- a/CasterSoundboard/CasterPlayer.cpp
+++ b/CasterSoundboard/CasterPlayer.cpp
@@ -132,6 +132,7 @@ CasterPlayerWidget::CasterPlayerWidget(QWidget* parent) : QWidget(parent)
     connect(player,SIGNAL(positionChanged(qint64)),this,SLOT(playerPositionChanged(qint64)));
     connect(player,SIGNAL(stateChanged(QMediaPlayer::State)),this,SLOT(playerStateChanged(QMediaPlayer::State)));
     connect(player,SIGNAL(metaDataChanged()),this,SLOT(playerMetaDataChanged()));
+    connect(player,SIGNAL(mediaStatusChanged(QMediaPlayer::MediaStatus)),this,SLOT(playerNewMediaStatus(QMediaPlayer::MediaStatus)));
 }
 
 //Set Properties
@@ -247,6 +248,19 @@ void CasterPlayerWidget::playerMetaDataChanged()
         player->stop();
     }
 
+}
+
+void CasterPlayerWidget::playerNewMediaStatus(QMediaPlayer::MediaStatus status)
+{
+    switch (status) {
+        case QMediaPlayer::LoadingMedia:
+            soundNameLabel->setText("Loading...");
+            soundNameLabel->setStyleSheet("color:darkblue;");
+            break;
+        default:
+            soundNameLabel->setStyleSheet("");
+            break;
+    }
 }
 
 //--------------

--- a/CasterSoundboard/CasterPlayer.h
+++ b/CasterSoundboard/CasterPlayer.h
@@ -51,6 +51,7 @@ public:
     //Player Methhods
     void playSound();//Plays sound
     void stopSound();//Stops sound
+    bool assignFile(const QString &path);
 
     //Properties
     QString *soundFilePath;
@@ -75,7 +76,6 @@ protected:
 private:
     //Private Methods
     int getProgressWidth(); //Use to compute width of progress bar
-    bool assignFile(const QString &path);
 
     // Internal state property
     enum State {

--- a/CasterSoundboard/CasterPlayer.h
+++ b/CasterSoundboard/CasterPlayer.h
@@ -74,6 +74,16 @@ private:
     //Private Methods
     int getProgressWidth(); //Use to compute width of progress bar
 
+    // Internal state property
+    enum State {
+        NoFile,
+        Loading,
+        Error,
+        Active
+    };
+
+    State state;
+
     //contained widgets:
     QVBoxLayout *mainLayout;
     QHBoxLayout *subMainLayoutH;
@@ -88,9 +98,6 @@ private:
     QPushButton *subMenuButton;
     QSlider *volumeSlider;
 
-    //Internal Properties
-    bool newMediaLoaded;
-
 signals:
     //MyWidget's signals....
 public slots:
@@ -104,5 +111,6 @@ public slots:
     void playerStateChanged(QMediaPlayer::State state);
     void playerMetaDataChanged();
     void playerNewMediaStatus(QMediaPlayer::MediaStatus status);
+    void playerError(QMediaPlayer::Error error);
 };
 #endif // CASTERPLAYER_H

--- a/CasterSoundboard/CasterPlayer.h
+++ b/CasterSoundboard/CasterPlayer.h
@@ -68,11 +68,14 @@ protected:
     void dragMoveEvent(QDragMoveEvent *event);
     void dragLeaveEvent(QDragLeaveEvent *event);
     void dropEvent(QDropEvent *event);
-    bool openFiles(const QStringList& pathList);
+    // Choose a file instead of dragging
+    void mousePressEvent(QMouseEvent* event);
+    bool openFiles(const QStringList &pathList);
 
 private:
     //Private Methods
     int getProgressWidth(); //Use to compute width of progress bar
+    bool assignFile(const QString &path);
 
     // Internal state property
     enum State {

--- a/CasterSoundboard/CasterPlayer.h
+++ b/CasterSoundboard/CasterPlayer.h
@@ -103,5 +103,6 @@ public slots:
     void playerPositionChanged(qint64 position);
     void playerStateChanged(QMediaPlayer::State state);
     void playerMetaDataChanged();
+    void playerNewMediaStatus(QMediaPlayer::MediaStatus status);
 };
 #endif // CASTERPLAYER_H

--- a/CasterSoundboard/CasterSoundboard.pro
+++ b/CasterSoundboard/CasterSoundboard.pro
@@ -31,3 +31,6 @@ FORMS    +=
 
 RESOURCES += \
     res.qrc
+
+target.path = $${PREFIX}/bin
+INSTALLS += target

--- a/CasterSoundboard/CasterSoundboard.pro
+++ b/CasterSoundboard/CasterSoundboard.pro
@@ -16,6 +16,7 @@ TEMPLATE = app
 SOURCES += main.cpp\
     CasterPlayer.cpp \
     CasterBoard.cpp \
+    CasterBoardLayout.cpp \
     MainWindow.cpp \
     CasterLabelColorPicker.cpp \
     CSS.cpp
@@ -23,6 +24,7 @@ SOURCES += main.cpp\
 HEADERS  += \
     CasterPlayer.h \
     CasterBoard.h \
+    CasterBoardLayout.h \
     CSS.h \
     MainWindow.h \
     CasterLabelColorPicker.h

--- a/CasterSoundboard/MainWindow.h
+++ b/CasterSoundboard/MainWindow.h
@@ -23,6 +23,7 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 #include <QWidget>
+#include <QSettings>
 
 //forward declarations
 class QTabWidget;
@@ -46,6 +47,7 @@ protected:
     //PROPERTIES
 
     //METHODS
+    void closeEvent(QCloseEvent *event) override;
 
     //WIDGETS
 
@@ -53,6 +55,7 @@ private:
     //PROPERTIES
 
     //METHODS
+    void restoreSettings();
 
     //WIDGETS
     QPushButton *addNewTabButton;

--- a/CasterSoundboard/mainwindow.cpp
+++ b/CasterSoundboard/mainwindow.cpp
@@ -59,11 +59,48 @@ MainWindow::MainWindow(QWidget *parent) : QWidget(parent)
     //SET LAYOUT
     this->setLayout(layout);
 
+    restoreSettings();
+
     //MAKE CONNECTIONS
     connect(aboutButton,SIGNAL(clicked()),this,SLOT(aboutBox()));
     connect(addNewTabButton,SIGNAL(clicked()),this,SLOT(addNewTab()));
     connect(mainTabContainer,SIGNAL(tabCloseRequested(int)),this,SLOT(mainTabContainerTabClosedRequested(int)));
+}
 
+void MainWindow::closeEvent(QCloseEvent *event)
+{
+    QSettings settings("Jupiter Broadcasting", "CasterSoundboard");
+
+    settings.beginWriteArray("boards");
+
+    for (int i = 0; i < mainTabContainer->count(); ++i) {
+        settings.setArrayIndex(i);
+        settings.setValue("title", mainTabContainer->tabText(i));
+
+        CasterBoard *cb;
+        cb = static_cast<CasterBoard*>(mainTabContainer->widget(i));
+        cb->saveLayout(settings);
+    }
+
+    settings.endArray();
+
+    event->accept();
+}
+
+void MainWindow::restoreSettings()
+{
+    QSettings settings("Jupiter Broadcasting", "CasterSoundboard");
+
+    int size = settings.beginReadArray("boards");
+
+    for (int i = 0; i < size; ++i) {
+        settings.setArrayIndex(i);
+
+        CasterBoard *cb = new CasterBoard;
+        mainTabContainer->addTab(cb, settings.value("title").toString());
+        cb->restoreLayout(settings);
+    }
+    settings.endArray();
 }
 
 //SLOTS

--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,16 @@ stdenv.mkDerivation {
   name = "CasterSoundboard";
   src = ./CasterSoundboard;
   nativeBuildInputs = [ qt5.qmakeHook qt5.makeQtWrapper ];
-  buildInputs = [ qt5.qtmultimedia ];
+  buildInputs = [
+    qt5.qtmultimedia
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+  ];
   enableParallelBuilding = true;
-  postInstall = "wrapQtProgram \"$out/bin/$name\"";
+  postInstall = ''
+    wrapQtProgram "$out/bin/$name" \
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+  '';
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+with import <nixpkgs> {};
+
+stdenv.mkDerivation {
+  name = "CasterSoundboard";
+  src = ./CasterSoundboard;
+  nativeBuildInputs = [ qt5.qmakeHook qt5.makeQtWrapper ];
+  buildInputs = [ qt5.qtmultimedia ];
+  enableParallelBuilding = true;
+  postInstall = "wrapQtProgram \"$out/bin/$name\"";
+}


### PR DESCRIPTION
This branch addresses a few things:

  * Refactor CasterBoard to use a `QHash` instead of replicating all the lines over and over, similar to what's been done in the meantime in #9 as well.
  * Show visual cue about player states (like `Loading...` or printing errors if they occur).
  * Allow to select files using a file dialogue instead of drag & drop.
  * Add a Nix expression file so the build is reproducible and build-time dependencies can be easily pulled in.
  * Load board layouts on startup and save them on exit (addressing #3).
  * Use the more readable approach from #9 for building up the layout.
  * Cherry-pick commit 8983c4edcca79753638733a79df510005cadefa5 (adds a `.gitignore`) from #9.