### PR TITLE
fixed the build instructions for Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ commands for various platforms are listed below:
 
 *Debian and Ubuntu*
 ```
-# apt install qtdeclarative5-dev qt5-default build-essentials
+# apt install qtdeclarative5-dev qt5-default qtmultimedia5-dev build-essential
 ```
 
 *Mac OSX*


### PR DESCRIPTION
Changed build-essentials to *build-essential*
Added dependency install for *qtmultimedia5-dev*

tested in Ubuntu 16.04 and the build works now.