### PR TITLE
Link to various places in the about box

### DIFF
--- a/CasterSoundboard/MainWindow.cpp
+++ b/CasterSoundboard/MainWindow.cpp
@@ -226,7 +226,7 @@ void MainWindow::updateCurrentOSCTab(int tabIndex)
 void MainWindow::aboutBox()
 {
     QMessageBox msgBox;
-    msgBox.setText("CasterSoundboard (v1.0) BETA<br>Author: Oscar Cerna<br>e-mail: covarianttensor@gmail.com<br>License: LGPL v3<br>© 2013-2017 Oscar Cerna");
+    msgBox.setText("CasterSoundboard (v1.0) BETA<br>Author: Oscar Cerna<br>e-mail: <a href=mailto:covarianttensor@gmail.com>covarianttensor@gmail.com</a><br>License: LGPL v3<br>© 2013-2017 Oscar Cerna");
     msgBox.setInformativeText("Special Note:<br>Developed for Chris Fisher & Jupiter Broadcasting, because he's awesome!<br>Visit <a href=""http://www.jupiterbroadcasting.com"">jupiterbroadcasting.com</a>.<br>NOT AFFILIATED with Chris Fisher or Jupiter Broadcasting.");
     msgBox.setStandardButtons(QMessageBox::Close);
     msgBox.setDefaultButton(QMessageBox::Close);

--- a/CasterSoundboard/MainWindow.cpp
+++ b/CasterSoundboard/MainWindow.cpp
@@ -227,7 +227,7 @@ void MainWindow::aboutBox()
 {
     QMessageBox msgBox;
     msgBox.setText("CasterSoundboard (v1.0) BETA<br>Author: Oscar Cerna<br>e-mail: covarianttensor@gmail.com<br>License: LGPL v3<br>© 2013-2017 Oscar Cerna");
-    msgBox.setInformativeText("Special Note:<br>Developed for Chris Fisher & Jupiter Broadcasting, because he's awesome!<br>Visit www.jupiterbroadcasting.com.<br>NOT AFFILIATED with Chris Fisher or Jupiter Broadcasting.");
+    msgBox.setInformativeText("Special Note:<br>Developed for Chris Fisher & Jupiter Broadcasting, because he's awesome!<br>Visit <a href=""http://www.jupiterbroadcasting.com"">jupiterbroadcasting.com</a>.<br>NOT AFFILIATED with Chris Fisher or Jupiter Broadcasting.");
     msgBox.setStandardButtons(QMessageBox::Close);
     msgBox.setDefaultButton(QMessageBox::Close);
     msgBox.setModal(true);

--- a/CasterSoundboard/MainWindow.cpp
+++ b/CasterSoundboard/MainWindow.cpp
@@ -226,8 +226,8 @@ void MainWindow::updateCurrentOSCTab(int tabIndex)
 void MainWindow::aboutBox()
 {
     QMessageBox msgBox;
-    msgBox.setText("CasterSoundboard (v1.0) BETA\nAuthor: Oscar Cerna\ne-mail: covarianttensor@gmail.com\nLicense: LGPL v3\n© 2013-2017 Oscar Cerna");
-    msgBox.setInformativeText("Special Note:\nDeveloped for Chris Fisher & Jupiter Broadcasting, because he's awesome!\nVisit www.jupiterbroadcasting.com.\nNOT AFFILIATED with Chris Fisher or Jupiter Broadcasting.");
+    msgBox.setText("CasterSoundboard (v1.0) BETA<br>Author: Oscar Cerna<br>e-mail: covarianttensor@gmail.com<br>License: LGPL v3<br>© 2013-2017 Oscar Cerna");
+    msgBox.setInformativeText("Special Note:<br>Developed for Chris Fisher & Jupiter Broadcasting, because he's awesome!<br>Visit www.jupiterbroadcasting.com.<br>NOT AFFILIATED with Chris Fisher or Jupiter Broadcasting.");
     msgBox.setStandardButtons(QMessageBox::Close);
     msgBox.setDefaultButton(QMessageBox::Close);
     msgBox.setModal(true);

--- a/CasterSoundboard/MainWindow.cpp
+++ b/CasterSoundboard/MainWindow.cpp
@@ -226,7 +226,7 @@ void MainWindow::updateCurrentOSCTab(int tabIndex)
 void MainWindow::aboutBox()
 {
     QMessageBox msgBox;
-    msgBox.setText("CasterSoundboard (v1.0) BETA<br>Author: Oscar Cerna<br>e-mail: <a href=mailto:covarianttensor@gmail.com>covarianttensor@gmail.com</a><br>License: LGPL v3<br>© 2013-2017 Oscar Cerna");
+    msgBox.setText("CasterSoundboard (v1.0) BETA<br>Author: <a href=""https://github.com/covarianttensor"">Oscar Cerna</a><br>e-mail: <a href=mailto:covarianttensor@gmail.com>covarianttensor@gmail.com</a><br>License: LGPL v3<br>© 2013-2017 Oscar Cerna");
     msgBox.setInformativeText("Special Note:<br>Developed for Chris Fisher & Jupiter Broadcasting, because he's awesome!<br>Visit <a href=""http://www.jupiterbroadcasting.com"">jupiterbroadcasting.com</a>.<br>NOT AFFILIATED with Chris Fisher or Jupiter Broadcasting.");
     msgBox.setStandardButtons(QMessageBox::Close);
     msgBox.setDefaultButton(QMessageBox::Close);

--- a/CasterSoundboard/MainWindow.cpp
+++ b/CasterSoundboard/MainWindow.cpp
@@ -226,7 +226,7 @@ void MainWindow::updateCurrentOSCTab(int tabIndex)
 void MainWindow::aboutBox()
 {
     QMessageBox msgBox;
-    msgBox.setText("CasterSoundboard (v1.0) BETA<br>Author: <a href=""https://github.com/covarianttensor"">Oscar Cerna</a><br>e-mail: <a href=mailto:covarianttensor@gmail.com>covarianttensor@gmail.com</a><br>License: LGPL v3<br>© 2013-2017 Oscar Cerna");
+    msgBox.setText("CasterSoundboard (v1.0) BETA<br>Author: <a href=""https://github.com/covarianttensor"">Oscar Cerna</a><br>e-mail: <a href=mailto:covarianttensor@gmail.com>covarianttensor@gmail.com</a><br>License: <a href=""https://github.com/JupiterBroadcasting/CasterSoundboard/blob/master/LICENSE"">LGPL v3</a><br>© 2013-2017 Oscar Cerna");
     msgBox.setInformativeText("Special Note:<br>Developed for Chris Fisher & Jupiter Broadcasting, because he's awesome!<br>Visit <a href=""http://www.jupiterbroadcasting.com"">jupiterbroadcasting.com</a>.<br>NOT AFFILIATED with Chris Fisher or Jupiter Broadcasting.");
     msgBox.setStandardButtons(QMessageBox::Close);
     msgBox.setDefaultButton(QMessageBox::Close);


### PR DESCRIPTION
I've split this up into a few commits so you can choose as many or as few things as you want to implement.

The first commit changes the the formatting from using plain-text (`\n` newlines) to HTML (`<br>` tags) to get it ready for adding links , the following commits add links to various parts of the dialog:

- Re-format to use HTML markup (no change)
![1-html](https://cloud.githubusercontent.com/assets/1242894/26325439/c2eeaf66-3f2e-11e7-8fe4-5640a32fb757.png)

- Make the website a link to http://www.jupiterbroadcasting.com/
![2-website](https://cloud.githubusercontent.com/assets/1242894/26325438/c2eb0a0a-3f2e-11e7-82f1-ea367c8c37c3.png)

- Make the e-mail a link to covarianttensor@gmail.com
![3-email](https://cloud.githubusercontent.com/assets/1242894/26325429/bc4d932a-3f2e-11e7-8c18-385b0188c079.png)

- Make the author a link to https://github.com/covarianttensor
![4-author](https://cloud.githubusercontent.com/assets/1242894/26325437/c2e99b66-3f2e-11e7-9701-45f87c63c3ea.png)

- Make the license a link to https://github.com/JupiterBroadcasting/CasterSoundboard/blob/master/LICENSE
![5-license](https://cloud.githubusercontent.com/assets/1242894/26325436/c2d00aac-3f2e-11e7-8856-98b22c3a59ec.png)


