### PR TITLE
Fixed issue with tab deletion and Issue #58.

### DIFF
--- a/CasterSoundboard/CasterPlayer.cpp
+++ b/CasterSoundboard/CasterPlayer.cpp
@@ -224,6 +224,10 @@ CasterPlayerWidget::CasterPlayerWidget(QWidget* parent) : QWidget(parent)
     connect(player,SIGNAL(metaDataChanged()),this,SLOT(playerMetaDataChanged()));
     connect(player,SIGNAL(durationChanged(qint64)),this,SLOT(playerDurationChanged(qint64)));
 }
+CasterPlayerWidget::~CasterPlayerWidget(void)
+{
+    delete player;
+}
 
 //Set Properties
 void CasterPlayerWidget::setHotKeyLetter(QString hotKey)

--- a/CasterSoundboard/CasterPlayer.cpp
+++ b/CasterSoundboard/CasterPlayer.cpp
@@ -59,7 +59,7 @@ CasterPlayerWidget::CasterPlayerWidget(QWidget* parent) : QWidget(parent)
     this->setAcceptDrops(true);
 
     //Init Player
-    player = new QMediaPlayer();
+    player = new QMediaPlayer(this);
     playStateImage = new QImage;
     playStateImage->load(":/res/img/playState_playing.png");
     //Init Properties
@@ -223,10 +223,6 @@ CasterPlayerWidget::CasterPlayerWidget(QWidget* parent) : QWidget(parent)
     connect(player,SIGNAL(stateChanged(QMediaPlayer::State)),this,SLOT(playerStateChanged(QMediaPlayer::State)));
     connect(player,SIGNAL(metaDataChanged()),this,SLOT(playerMetaDataChanged()));
     connect(player,SIGNAL(durationChanged(qint64)),this,SLOT(playerDurationChanged(qint64)));
-}
-CasterPlayerWidget::~CasterPlayerWidget(void)
-{
-    delete player;
 }
 
 //Set Properties

--- a/CasterSoundboard/CasterPlayer.h
+++ b/CasterSoundboard/CasterPlayer.h
@@ -46,7 +46,6 @@ class CasterPlayerWidget : public QWidget //inherit from QWidget
 public:
     //Constructor
     CasterPlayerWidget(QWidget* parent = 0); //don't forget to pass the parent
-    ~CasterPlayerWidget();
 
     //Set Properties
     void setHotKeyLetter(QString hotKey);

--- a/CasterSoundboard/CasterPlayer.h
+++ b/CasterSoundboard/CasterPlayer.h
@@ -46,6 +46,7 @@ class CasterPlayerWidget : public QWidget //inherit from QWidget
 public:
     //Constructor
     CasterPlayerWidget(QWidget* parent = 0); //don't forget to pass the parent
+    ~CasterPlayerWidget();
 
     //Set Properties
     void setHotKeyLetter(QString hotKey);

--- a/CasterSoundboard/MainWindow.cpp
+++ b/CasterSoundboard/MainWindow.cpp
@@ -187,10 +187,14 @@ void MainWindow::mainTabContainerTabClosedRequested(int tabIndex)
     msgBox.setModal(true);
     if(msgBox.exec() == QMessageBox::Yes)
     {
+        CasterBoard *toBeDeleted = dynamic_cast<CasterBoard*>(mainTabContainer->widget(tabIndex));
         //CLOSE REQUESTED TAB
-        disconnect(dynamic_cast<CasterBoard*>(mainTabContainer->widget(tabIndex)), SIGNAL(globalHotKeyReleasedEvent(QKeyEvent*)),this,SLOT(handleGlobalHotKeyEventFromCurrentWidget(QKeyEvent*)));
-        disconnect(dynamic_cast<CasterBoard*>(mainTabContainer->widget(tabIndex)), SIGNAL(_updateOSCClient(OscMessageComposer)),this,SLOT(sendOSCMessageToClient(OscMessageComposer)));
+        disconnect(toBeDeleted, SIGNAL(globalHotKeyReleasedEvent(QKeyEvent*)),this,SLOT(handleGlobalHotKeyEventFromCurrentWidget(QKeyEvent*)));
+        disconnect(toBeDeleted, SIGNAL(_updateOSCClient(OscMessageComposer)),this,SLOT(sendOSCMessageToClient(OscMessageComposer)));
         mainTabContainer->removeTab(tabIndex);
+        if(toBeDeleted) {
+            delete toBeDeleted;
+        }
     }
 }
 


### PR DESCRIPTION
- MainWindow::mainTabContainerClosedRequested would remove the given
tab from the container, but would not delete the tab. (removeTab does
not delete the object) The tab is now deleted.
- CasterPlayerWidget 's player is now attached to the object tree.